### PR TITLE
Pipe

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -109,7 +109,7 @@
         "no-shadow-restricted-names": [ 2 ],
         "no-undef": [ 2 ],
         "no-undef-init": [ 2 ],
-        "no-undefined": [ 2 ],
+        // "no-undefined": [ 2 ],
         "no-unused-vars": [ 2, { "vars": "all", "args": "none" } ],
         "no-use-before-define": [ 2, "nofunc" ],
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An Observable implementation compatible with the Falcor DataSource API.
 
 Unless you are implementing a Falcor DataSource you will likely be better
-served by the more fully featured [RxJS]. 
+served by the more fully featured [RxJS].
 
 ## Error handling policy
 
@@ -46,6 +46,24 @@ rxobs.subscribe({
     console.log("next", value);
   }
 });
+```
+
+## Applying operators to an Observable
+
+The `pipe` instance method can be used to apply operators to an Observable.
+
+```js
+const { Observable, operators: { map } } = require("falcor-observable");
+
+Observable.of(1,2,3)
+  .pipe(
+    map(x => x + 1),
+    map(x => x + 1))
+  .subscribe({
+    onNext(value) {
+      console.log("onNext", value);
+    }
+  });
 ```
 
 [RxJS]: https://www.npmjs.com/package/rxjs

--- a/src/classic-observable.js
+++ b/src/classic-observable.js
@@ -12,7 +12,8 @@ const { ClassicFromEsSubscriptionObserver } = require("./classic-observer");
 import type {
   IAdaptsToObservable,
   IObservable,
-  ISubscription
+  ISubscription,
+  Operator
 } from "./es-observable";
 
 export interface IDisposable {
@@ -133,6 +134,88 @@ class ClassicObservable<T, E = Error> extends BaseObservable<T, E>
       return ({ unsubscribe: cleanup.dispose }: any);
     });
   }
+
+  pipe: (() => ClassicObservable<T, E>) &
+    (<R>(op1: Operator<T, R, E>) => ClassicObservable<R, E>) &
+    (<R1, R2>(
+      op1: Operator<T, R1, E>,
+      op2: Operator<R1, R2, E>
+    ) => ClassicObservable<R2, E>) &
+    (<R1, R2, R3>(
+      op1: Operator<T, R1, E>,
+      op2: Operator<R1, R2, E>,
+      op3: Operator<R2, R3, E>
+    ) => ClassicObservable<R3, E>) &
+    (<R1, R2, R3, R4>(
+      op1: Operator<T, R1, E>,
+      op2: Operator<R1, R2, E>,
+      op3: Operator<R2, R3, E>,
+      op4: Operator<R3, R4, E>
+    ) => ClassicObservable<R4, E>) &
+    (<R1, R2, R3, R4, R5>(
+      op1: Operator<T, R1, E>,
+      op2: Operator<R1, R2, E>,
+      op3: Operator<R2, R3, E>,
+      op4: Operator<R3, R4, E>,
+      op5: Operator<R4, R5, E>
+    ) => ClassicObservable<R5, E>) &
+    (<R1, R2, R3, R4, R5, R6>(
+      op1: Operator<T, R1, E>,
+      op2: Operator<R1, R2, E>,
+      op3: Operator<R2, R3, E>,
+      op4: Operator<R3, R4, E>,
+      op5: Operator<R4, R5, E>,
+      op6: Operator<R5, R6, E>
+    ) => ClassicObservable<R6, E>) &
+    (<R1, R2, R3, R4, R5, R6, R7>(
+      op1: Operator<T, R1, E>,
+      op2: Operator<R1, R2, E>,
+      op3: Operator<R2, R3, E>,
+      op4: Operator<R3, R4, E>,
+      op5: Operator<R4, R5, E>,
+      op6: Operator<R5, R6, E>,
+      op7: Operator<R6, R7, E>
+    ) => ClassicObservable<R7, E>) &
+    (<R1, R2, R3, R4, R5, R6, R7, R8>(
+      op1: Operator<T, R1, E>,
+      op2: Operator<R1, R2, E>,
+      op3: Operator<R2, R3, E>,
+      op4: Operator<R3, R4, E>,
+      op5: Operator<R4, R5, E>,
+      op6: Operator<R5, R6, E>,
+      op7: Operator<R6, R7, E>,
+      op8: Operator<R7, R8, E>
+    ) => ClassicObservable<R8, E>) &
+    (<R1, R2, R3, R4, R5, R6, R7, R8, R9>(
+      op1: Operator<T, R1, E>,
+      op2: Operator<R1, R2, E>,
+      op3: Operator<R2, R3, E>,
+      op4: Operator<R3, R4, E>,
+      op5: Operator<R4, R5, E>,
+      op6: Operator<R5, R6, E>,
+      op7: Operator<R6, R7, E>,
+      op8: Operator<R7, R8, E>,
+      op9: Operator<R8, R9, E>
+    ) => ClassicObservable<R9, E>) &
+    (<R1, R2, R3, R4, R5, R6, R7, R8, R9, R10>(
+      op1: Operator<T, R1, E>,
+      op2: Operator<R1, R2, E>,
+      op3: Operator<R2, R3, E>,
+      op4: Operator<R3, R4, E>,
+      op5: Operator<R4, R5, E>,
+      op6: Operator<R5, R6, E>,
+      op7: Operator<R6, R7, E>,
+      op8: Operator<R7, R8, E>,
+      op9: Operator<R8, R9, E>,
+      op10: Operator<R9, R10, E>
+    ) => ClassicObservable<R10, E>) &
+    (<R>(operators: Operator<T, R, E>) => ClassicObservable<R, E>);
 }
+
+ClassicObservable.prototype.pipe = (function pipe(...operators) {
+  return ClassicObservable.from(
+    operators.reduce((acc, curr) => curr(acc), this[symbolObservable]())
+  );
+}: any);
 
 module.exports = { Observable: ClassicObservable };

--- a/src/classic-observable.js
+++ b/src/classic-observable.js
@@ -8,11 +8,11 @@ const {
   Observable: EsObservable,
   Subscription
 } = require("./es-observable");
+const { ClassicFromEsSubscriptionObserver } = require("./classic-observer");
 
 import type {
   IAdaptsToObservable,
   IObservable,
-  ISubscriptionObserver,
   ISubscription
 } from "./es-observable";
 
@@ -73,27 +73,6 @@ class EsFromClassicObserver<T, E = Error> {
     if (typeof onCompleted === "function") {
       onCompleted.call(observer);
     }
-  }
-}
-
-// XXX Should these go directly on SubscriptionObserver?
-class ClassicFromEsSubscriptionObserver<T, E = Error>
-  implements IClassicSubscriptionObserver<T, E> {
-  _observer: ISubscriptionObserver<T, E>;
-  constructor(observer: ISubscriptionObserver<T, E>): void {
-    this._observer = observer;
-  }
-  onNext(value: T): void {
-    this._observer.next(value);
-  }
-  onError(errorValue: E): void {
-    this._observer.error(errorValue);
-  }
-  onCompleted(): void {
-    this._observer.complete();
-  }
-  get isStopped(): boolean {
-    return this._observer.closed;
   }
 }
 

--- a/src/classic-observable.js
+++ b/src/classic-observable.js
@@ -1,5 +1,4 @@
 // @flow
-/* eslint-disable no-undefined */
 "use strict";
 
 const symbolObservable = require("symbol-observable").default;

--- a/src/classic-observer.js
+++ b/src/classic-observer.js
@@ -1,5 +1,4 @@
 // @flow
-/* eslint-disable no-undefined */
 "use strict";
 
 import type { ISubscriptionObserver } from "./es-observable";

--- a/src/classic-observer.js
+++ b/src/classic-observer.js
@@ -1,0 +1,35 @@
+// @flow
+/* eslint-disable no-undefined */
+"use strict";
+
+import type { ISubscriptionObserver } from "./es-observable";
+
+export interface IClassicSubscriptionObserver<T, E = Error> {
+  onNext(value: T): void;
+  onError(error: E): void;
+  onCompleted(): void;
+  +isStopped: boolean;
+}
+
+// XXX Should these go directly on SubscriptionObserver?
+class ClassicFromEsSubscriptionObserver<T, E = Error>
+  implements IClassicSubscriptionObserver<T, E> {
+  _observer: ISubscriptionObserver<T, E>;
+  constructor(observer: ISubscriptionObserver<T, E>): void {
+    this._observer = observer;
+  }
+  onNext(value: T): void {
+    this._observer.next(value);
+  }
+  onError(errorValue: E): void {
+    this._observer.error(errorValue);
+  }
+  onCompleted(): void {
+    this._observer.complete();
+  }
+  get isStopped(): boolean {
+    return this._observer.closed;
+  }
+}
+
+module.exports = { ClassicFromEsSubscriptionObserver };

--- a/src/es-observable.js
+++ b/src/es-observable.js
@@ -50,6 +50,10 @@ export interface IObservable<T, E = Error> extends IAdaptsToObservable<T, E> {
   ): ISubscription;
 }
 
+export type Operator<T, R, E = Error> = (
+  EsObservable<T, E>
+) => EsObservable<R, E>;
+
 // Functions to be called within tryCatch().
 
 function callNext<T, E>(observer: Observer<T, E>, value: T): void {
@@ -311,7 +315,87 @@ class EsObservable<T, E = Error> extends BaseObservable<T, E>
     const C = typeof this === "function" ? this : (EsObservable: any);
     return super.from.call(C, obsOrIter);
   }
+
+  pipe: (() => EsObservable<T, E>) &
+    (<R>(op1: Operator<T, R, E>) => EsObservable<R, E>) &
+    (<R1, R2>(
+      op1: Operator<T, R1, E>,
+      op2: Operator<R1, R2, E>
+    ) => EsObservable<R2, E>) &
+    (<R1, R2, R3>(
+      op1: Operator<T, R1, E>,
+      op2: Operator<R1, R2, E>,
+      op3: Operator<R2, R3, E>
+    ) => EsObservable<R3, E>) &
+    (<R1, R2, R3, R4>(
+      op1: Operator<T, R1, E>,
+      op2: Operator<R1, R2, E>,
+      op3: Operator<R2, R3, E>,
+      op4: Operator<R3, R4, E>
+    ) => EsObservable<R4, E>) &
+    (<R1, R2, R3, R4, R5>(
+      op1: Operator<T, R1, E>,
+      op2: Operator<R1, R2, E>,
+      op3: Operator<R2, R3, E>,
+      op4: Operator<R3, R4, E>,
+      op5: Operator<R4, R5, E>
+    ) => EsObservable<R5, E>) &
+    (<R1, R2, R3, R4, R5, R6>(
+      op1: Operator<T, R1, E>,
+      op2: Operator<R1, R2, E>,
+      op3: Operator<R2, R3, E>,
+      op4: Operator<R3, R4, E>,
+      op5: Operator<R4, R5, E>,
+      op6: Operator<R5, R6, E>
+    ) => EsObservable<R6, E>) &
+    (<R1, R2, R3, R4, R5, R6, R7>(
+      op1: Operator<T, R1, E>,
+      op2: Operator<R1, R2, E>,
+      op3: Operator<R2, R3, E>,
+      op4: Operator<R3, R4, E>,
+      op5: Operator<R4, R5, E>,
+      op6: Operator<R5, R6, E>,
+      op7: Operator<R6, R7, E>
+    ) => EsObservable<R7, E>) &
+    (<R1, R2, R3, R4, R5, R6, R7, R8>(
+      op1: Operator<T, R1, E>,
+      op2: Operator<R1, R2, E>,
+      op3: Operator<R2, R3, E>,
+      op4: Operator<R3, R4, E>,
+      op5: Operator<R4, R5, E>,
+      op6: Operator<R5, R6, E>,
+      op7: Operator<R6, R7, E>,
+      op8: Operator<R7, R8, E>
+    ) => EsObservable<R8, E>) &
+    (<R1, R2, R3, R4, R5, R6, R7, R8, R9>(
+      op1: Operator<T, R1, E>,
+      op2: Operator<R1, R2, E>,
+      op3: Operator<R2, R3, E>,
+      op4: Operator<R3, R4, E>,
+      op5: Operator<R4, R5, E>,
+      op6: Operator<R5, R6, E>,
+      op7: Operator<R6, R7, E>,
+      op8: Operator<R7, R8, E>,
+      op9: Operator<R8, R9, E>
+    ) => EsObservable<R9, E>) &
+    (<R1, R2, R3, R4, R5, R6, R7, R8, R9, R10>(
+      op1: Operator<T, R1, E>,
+      op2: Operator<R1, R2, E>,
+      op3: Operator<R2, R3, E>,
+      op4: Operator<R3, R4, E>,
+      op5: Operator<R4, R5, E>,
+      op6: Operator<R5, R6, E>,
+      op7: Operator<R6, R7, E>,
+      op8: Operator<R7, R8, E>,
+      op9: Operator<R8, R9, E>,
+      op10: Operator<R9, R10, E>
+    ) => EsObservable<R10, E>) &
+    (<R>(operators: Operator<T, R, E>) => EsObservable<R, E>);
 }
+
+EsObservable.prototype.pipe = (function pipe(...operators) {
+  return operators.reduce((acc, curr) => curr(acc), this);
+}: any);
 
 module.exports = {
   BaseObservable,

--- a/src/es-observable.js
+++ b/src/es-observable.js
@@ -3,6 +3,8 @@
 "use strict";
 
 const symbolObservable = require("symbol-observable").default;
+const { ClassicFromEsSubscriptionObserver } = require("./classic-observer");
+import type { IClassicObservable } from "./classic-observable";
 
 export interface ISubscriptionObserver<T, E = Error> {
   next(value: T): void;
@@ -33,6 +35,7 @@ export interface IAdaptsToObservable<T, E = Error> {
   // Flow cannot parse computed properties.
   //[symbolObservable](): IObservable<T, E>
 }
+type ObservableFrom<T, E> = IAdaptsToObservable<T, E> | Iterable<T>;
 
 export interface IObservable<T, E = Error> extends IAdaptsToObservable<T, E> {
   subscribe(
@@ -262,7 +265,7 @@ class BaseObservable<T, E = Error> {
     });
   }
 
-  static from(obsOrIter: IAdaptsToObservable<T, E> | Iterable<T>): this {
+  static from(obsOrIter: ObservableFrom<T, E>): this {
     if (typeof obsOrIter === "undefined" || obsOrIter === null) {
       throw new TypeError();
     }
@@ -299,6 +302,21 @@ class BaseObservable<T, E = Error> {
     }
 
     throw new TypeError();
+  }
+
+  static fromClassicObservable(classic: IClassicObservable<T, E>): this {
+    if (symbolObservable in classic) {
+      return this.from(classic);
+    }
+    if (typeof classic.subscribe !== "function") {
+      throw new TypeError();
+    }
+    return new this(observer => {
+      const disposable = classic.subscribe(
+        new ClassicFromEsSubscriptionObserver(observer)
+      );
+      return () => disposable.dispose();
+    });
   }
 
   static empty(): this {
@@ -342,7 +360,7 @@ class EsObservable<T, E = Error> extends BaseObservable<T, E>
     return super.of.call(C, ...values);
   }
 
-  static from(obsOrIter: IAdaptsToObservable<T, E> | Iterable<T>): this {
+  static from(obsOrIter: ObservableFrom<T, E>): this {
     const C = typeof this === "function" ? this : (EsObservable: any);
     return super.from.call(C, obsOrIter);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,11 @@
 export type {
   IDisposable,
   IClassicObservable as IObservable,
-  IClassicSubscriptionObserver as IObserver,
   ClassicObserver as PartialObserver
 } from "./classic-observable";
+export type {
+  IClassicSubscriptionObserver as IObserver
+} from "./classic-observer";
 
 const { Observable } = require("./classic-observable");
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,5 +10,6 @@ export type {
 } from "./classic-observer";
 
 const { Observable } = require("./classic-observable");
+const operators = require("./operators");
 
-module.exports = { Observable };
+module.exports = { Observable, operators };

--- a/src/operators/index.js
+++ b/src/operators/index.js
@@ -1,0 +1,3 @@
+// @flow
+"use strict";
+module.exports.map = require("./map").map;

--- a/src/operators/map.js
+++ b/src/operators/map.js
@@ -1,0 +1,35 @@
+// @flow
+"use strict";
+
+import type { ISubscriptionObserver, ISubscription } from "../es-observable.js";
+const { Observable } = require("../es-observable.js");
+const { tryCatchResult, symbolError, popError } = require("../try-catch");
+
+function map<T, R, E: Error>(
+  project: (T, number) => R,
+  thisArg?: any
+): (Observable<T, E>) => Observable<R, E> {
+  return function mapOperator(source: Observable<T, E>): Observable<R, E> {
+    return new Observable(observer => {
+      let index: number = 0;
+      return source.subscribe({
+        next(v) {
+          const result = tryCatchResult.call(thisArg, project, v, index++);
+          if (result === symbolError) {
+            observer.error((popError(): any));
+            return;
+          }
+          observer.next(result);
+        },
+        error(e) {
+          observer.error(e);
+        },
+        complete() {
+          observer.complete();
+        }
+      });
+    });
+  };
+}
+
+module.exports = { map };

--- a/src/try-catch.js
+++ b/src/try-catch.js
@@ -1,0 +1,63 @@
+// @flow
+"use strict";
+
+const symbolError = Symbol("try-catch-error");
+let lastError: ?{ e: Error } = null;
+
+function popError(): Error {
+  if (!lastError) {
+    throw new Error("popError may only be called once");
+  }
+  const { e } = lastError;
+  lastError = null;
+  return e;
+}
+
+let tryCatch: ((f: () => void) => void) &
+  (<A>(f: (a: A) => void, a: A) => void) &
+  (<A, B>(f: (a: A, b: B) => void, a: A, b: B) => void) &
+  (<A, B, C>(f: (a: A, b: B, c: C) => void, a: A, b: B, c: C) => void);
+
+let tryCatchResult: (<R>(f: () => R) => R | typeof symbolError) &
+  (<A, R>(f: (a: A) => R, a: A) => R | typeof symbolError) &
+  (<A, B, R>(f: (a: A, b: B) => R, a: A, b: B) => R | typeof symbolError) &
+  (<A, B, C, R>(
+    f: (a: A, b: B, c: C) => R,
+    a: A,
+    b: B,
+    c: C
+  ) => R | typeof symbolError);
+
+if (process.env.FALCOR_OBSERVABLE_NO_CATCH) {
+  tryCatch = (function dontTryCatch(f, ...args) {
+    f.call(this, ...args);
+  }: any);
+
+  tryCatchResult = (function dontTryCatchResult(f, ...args) {
+    return f.call(this, ...args);
+  }: any);
+} else {
+  const throwError = (e: Error) => {
+    throw e;
+  };
+
+  tryCatch = (function doTryCatch(f, ...args) {
+    try {
+      f.call(this, ...args);
+    } catch (e) {
+      // See https://github.com/ReactiveX/rxjs/issues/3004#issuecomment-339720668
+      setImmediate(throwError, e);
+    }
+  }: any);
+
+  tryCatchResult = (function doTryCatchResult(f, ...args) {
+    try {
+      return f.call(this, ...args);
+    } catch (e) {
+      lastError = { e };
+      return symbolError;
+    }
+  }: any);
+}
+
+module.exports = { tryCatch, tryCatchResult, symbolError, popError };

--- a/test/classic-observable-test.js
+++ b/test/classic-observable-test.js
@@ -4,54 +4,83 @@ const { Observable } = require("../src/classic-observable");
 const { expect } = require("chai");
 const { stub } = require("sinon");
 
-describe("Observable subscribe", function() {
-  it("functions", function(done) {
-    const onNext = stub();
-    Observable.of(1, 2, 3).subscribe(onNext, done, () => {
+describe("Classic Observable", function() {
+  describe("subscribe", function() {
+    it("functions", function(done) {
+      const onNext = stub();
+      Observable.of(1, 2, 3).subscribe(onNext, done, () => {
+        expect(onNext.args).to.deep.equal([[1], [2], [3]]);
+        done();
+      });
+    });
+
+    it("only onNext function", function() {
+      const onNext = stub();
+      Observable.of(1, 2, 3).subscribe(onNext);
       expect(onNext.args).to.deep.equal([[1], [2], [3]]);
-      done();
+    });
+
+    it("only onNext partial observer", function() {
+      const onNext = stub();
+      Observable.of(1, 2, 3).subscribe({ onNext });
+      expect(onNext.args).to.deep.equal([[1], [2], [3]]);
+    });
+
+    it("only onError partial observer", function() {
+      const onError = stub();
+      const err = new Error("Err");
+      Observable.throw(err).subscribe({ onError });
+      expect(onError.args).to.deep.equal([[err]]);
+    });
+
+    it("only onError function", function() {
+      const onError = stub();
+      const err = new Error("Err");
+      Observable.throw(err).subscribe(null, onError);
+      expect(onError.args).to.deep.equal([[err]]);
+    });
+
+    it("only onCompleted partial observer", function(done) {
+      Observable.of(1, 2, 3).subscribe({ onCompleted: done });
+    });
+
+    it("only onCompleted function", function(done) {
+      Observable.of(1, 2, 3).subscribe(null, null, done);
+    });
+
+    it("no arguments", function() {
+      Observable.of(1, 2, 3).subscribe();
+    });
+
+    it("empty partial observer", function() {
+      Observable.of(1, 2, 3).subscribe({});
     });
   });
 
-  it("only onNext function", function() {
-    const onNext = stub();
-    Observable.of(1, 2, 3).subscribe(onNext);
-    expect(onNext.args).to.deep.equal([[1], [2], [3]]);
-  });
-
-  it("only onNext partial observer", function() {
-    const onNext = stub();
-    Observable.of(1, 2, 3).subscribe({ onNext });
-    expect(onNext.args).to.deep.equal([[1], [2], [3]]);
-  });
-
-  it("only onError partial observer", function() {
-    const onError = stub();
-    const err = new Error("Err");
-    Observable.throw(err).subscribe({ onError });
-    expect(onError.args).to.deep.equal([[err]]);
-  });
-
-  it("only onError function", function() {
-    const onError = stub();
-    const err = new Error("Err");
-    Observable.throw(err).subscribe(null, onError);
-    expect(onError.args).to.deep.equal([[err]]);
-  });
-
-  it("only onCompleted partial observer", function(done) {
-    Observable.of(1, 2, 3).subscribe({ onCompleted: done });
-  });
-
-  it("only onCompleted function", function(done) {
-    Observable.of(1, 2, 3).subscribe(null, null, done);
-  });
-
-  it("no arguments", function() {
-    Observable.of(1, 2, 3).subscribe();
-  });
-
-  it("empty partial observer", function() {
-    Observable.of(1, 2, 3).subscribe({});
+  describe("fromClassicObservable", function() {
+    it("adapts from classic observable", function() {
+      const disposable = {
+        isDisposed: false,
+        dispose() {
+          this.isDisposed = true;
+        }
+      };
+      let observer;
+      const classic = {
+        subscribe(obs, onError, onCompleted) {
+          observer = obs;
+          return disposable;
+        }
+      };
+      const obs = Observable.fromClassicObservable(classic);
+      const onNext = stub();
+      const onError = stub();
+      const onCompleted = stub();
+      const subscription = obs.subscribe({ onNext, onError, onCompleted });
+      (observer: any).onNext(1);
+      expect(onNext.args).to.deep.equal([[1]]);
+      subscription.dispose();
+      expect(disposable.isDisposed).to.equal(true);
+    });
   });
 });

--- a/test/classic-observable-test.js
+++ b/test/classic-observable-test.js
@@ -1,6 +1,7 @@
 // @flow
 "use strict";
 const { Observable } = require("../src/classic-observable");
+const { map } = require("../src/operators/map");
 const { expect } = require("chai");
 const { stub } = require("sinon");
 
@@ -81,6 +82,22 @@ describe("Classic Observable", function() {
       expect(onNext.args).to.deep.equal([[1]]);
       subscription.dispose();
       expect(disposable.isDisposed).to.equal(true);
+    });
+  });
+
+  describe("pipe", function() {
+    it("pipes", function() {
+      const onNext = stub();
+      const onError = stub();
+      const onCompleted = stub();
+
+      Observable.of(0, 1, 2)
+        .pipe(map(x => x + 1), map(x => x + 1))
+        .subscribe({ onNext, onError, onCompleted });
+
+      expect(onNext.args).to.deep.equal([[2], [3], [4]]);
+      expect(onError.called).equal(false);
+      expect(onCompleted.calledOnce).equal(true);
     });
   });
 });

--- a/test/es-observable-test.js
+++ b/test/es-observable-test.js
@@ -1,6 +1,7 @@
 // @flow
 "use strict";
 const { Observable } = require("../src/es-observable");
+const { map } = require("../src/operators/map");
 const { expect } = require("chai");
 const { stub } = require("sinon");
 
@@ -81,6 +82,22 @@ describe("ES Observable", function() {
       expect(next.args).to.deep.equal([[1]]);
       subscription.unsubscribe();
       expect(disposable.isDisposed).to.equal(true);
+    });
+  });
+
+  describe("pipe", function() {
+    it("pipes", function() {
+      const next = stub();
+      const error = stub();
+      const complete = stub();
+
+      Observable.of(0, 1, 2)
+        .pipe(map(x => x + 1), map(x => x + 1))
+        .subscribe({ next, error, complete });
+
+      expect(next.args).to.deep.equal([[2], [3], [4]]);
+      expect(error.called).equal(false);
+      expect(complete.calledOnce).equal(true);
     });
   });
 });

--- a/test/es-observable-test.js
+++ b/test/es-observable-test.js
@@ -4,81 +4,83 @@ const { Observable } = require("../src/es-observable");
 const { expect } = require("chai");
 const { stub } = require("sinon");
 
-describe("ES Observable subscribe", function() {
-  it("functions", function(done) {
-    const next = stub();
-    Observable.of(1, 2, 3).subscribe(next, done, () => {
+describe("ES Observable", function() {
+  describe("subscribe", function() {
+    it("functions", function(done) {
+      const next = stub();
+      Observable.of(1, 2, 3).subscribe(next, done, () => {
+        expect(next.args).to.deep.equal([[1], [2], [3]]);
+        done();
+      });
+    });
+
+    it("only next function", function() {
+      const next = stub();
+      Observable.of(1, 2, 3).subscribe(next);
       expect(next.args).to.deep.equal([[1], [2], [3]]);
-      done();
+    });
+
+    it("only next partial observer", function() {
+      const next = stub();
+      Observable.of(1, 2, 3).subscribe({ next });
+      expect(next.args).to.deep.equal([[1], [2], [3]]);
+    });
+
+    it("only error partial observer", function() {
+      const error = stub();
+      const err = new Error("Err");
+      Observable.throw(err).subscribe({ error });
+      expect(error.args).to.deep.equal([[err]]);
+    });
+
+    it("only error function", function() {
+      const error = stub();
+      const err = new Error("Err");
+      Observable.throw(err).subscribe(null, error);
+      expect(error.args).to.deep.equal([[err]]);
+    });
+
+    it("only complete partial observer", function(done) {
+      Observable.of(1, 2, 3).subscribe({ complete: done });
+    });
+
+    it("only complete function", function(done) {
+      Observable.of(1, 2, 3).subscribe(null, null, done);
+    });
+
+    it("no arguments", function() {
+      Observable.of(1, 2, 3).subscribe();
+    });
+
+    it("empty partial observer", function() {
+      Observable.of(1, 2, 3).subscribe({});
     });
   });
 
-  it("only next function", function() {
-    const next = stub();
-    Observable.of(1, 2, 3).subscribe(next);
-    expect(next.args).to.deep.equal([[1], [2], [3]]);
-  });
-
-  it("only next partial observer", function() {
-    const next = stub();
-    Observable.of(1, 2, 3).subscribe({ next });
-    expect(next.args).to.deep.equal([[1], [2], [3]]);
-  });
-
-  it("only error partial observer", function() {
-    const error = stub();
-    const err = new Error("Err");
-    Observable.throw(err).subscribe({ error });
-    expect(error.args).to.deep.equal([[err]]);
-  });
-
-  it("only error function", function() {
-    const error = stub();
-    const err = new Error("Err");
-    Observable.throw(err).subscribe(null, error);
-    expect(error.args).to.deep.equal([[err]]);
-  });
-
-  it("only complete partial observer", function(done) {
-    Observable.of(1, 2, 3).subscribe({ complete: done });
-  });
-
-  it("only complete function", function(done) {
-    Observable.of(1, 2, 3).subscribe(null, null, done);
-  });
-
-  it("no arguments", function() {
-    Observable.of(1, 2, 3).subscribe();
-  });
-
-  it("empty partial observer", function() {
-    Observable.of(1, 2, 3).subscribe({});
-  });
-});
-
-describe("ES Observable fromClassicObservable", function() {
-  it("adapts from classic observable", function() {
-    const disposable = {
-      isDisposed: false,
-      dispose() {
-        this.isDisposed = true;
-      }
-    };
-    let observer;
-    const classic = {
-      subscribe(obs, onError, onCompleted) {
-        observer = obs;
-        return disposable;
-      }
-    };
-    const obs = Observable.fromClassicObservable(classic);
-    const next = stub();
-    const error = stub();
-    const complete = stub();
-    const subscription = obs.subscribe({ next, error, complete });
-    (observer: any).onNext(1);
-    expect(next.args).to.deep.equal([[1]]);
-    subscription.unsubscribe();
-    expect(disposable.isDisposed).to.equal(true);
+  describe("fromClassicObservable", function() {
+    it("adapts from classic observable", function() {
+      const disposable = {
+        isDisposed: false,
+        dispose() {
+          this.isDisposed = true;
+        }
+      };
+      let observer;
+      const classic = {
+        subscribe(obs, onError, onCompleted) {
+          observer = obs;
+          return disposable;
+        }
+      };
+      const obs = Observable.fromClassicObservable(classic);
+      const next = stub();
+      const error = stub();
+      const complete = stub();
+      const subscription = obs.subscribe({ next, error, complete });
+      (observer: any).onNext(1);
+      expect(next.args).to.deep.equal([[1]]);
+      subscription.unsubscribe();
+      expect(disposable.isDisposed).to.equal(true);
+    });
   });
 });

--- a/test/es-observable-test.js
+++ b/test/es-observable-test.js
@@ -55,3 +55,30 @@ describe("ES Observable subscribe", function() {
     Observable.of(1, 2, 3).subscribe({});
   });
 });
+
+describe("ES Observable fromClassicObservable", function() {
+  it("adapts from classic observable", function() {
+    const disposable = {
+      isDisposed: false,
+      dispose() {
+        this.isDisposed = true;
+      }
+    };
+    let observer;
+    const classic = {
+      subscribe(obs, onError, onCompleted) {
+        observer = obs;
+        return disposable;
+      }
+    };
+    const obs = Observable.fromClassicObservable(classic);
+    const next = stub();
+    const error = stub();
+    const complete = stub();
+    const subscription = obs.subscribe({ next, error, complete });
+    (observer: any).onNext(1);
+    expect(next.args).to.deep.equal([[1]]);
+    subscription.unsubscribe();
+    expect(disposable.isDisposed).to.equal(true);
+  });
+});

--- a/test/map-test.js
+++ b/test/map-test.js
@@ -1,0 +1,25 @@
+// @flow
+"use strict";
+const { Observable } = require("../src/es-observable");
+const { expect } = require("chai");
+const { stub } = require("sinon");
+const { map } = require("../src/operators/map");
+
+describe("map function", function() {
+  it("transforms values", function() {
+    const observable = Observable.of(0, 1, 2);
+    const next = stub();
+    const error = stub();
+    const complete = stub();
+
+    map((value, index) => [value, index])(observable).subscribe({
+      next,
+      error,
+      complete
+    });
+
+    expect(next.args).to.deep.equal([[[0, 0]], [[1, 1]], [[2, 2]]]);
+    expect(error.called).equal(false);
+    expect(complete.calledOnce).equal(true);
+  });
+});


### PR DESCRIPTION
Best to look at this commit by commit, the first two are preparatory.

Function signature of map operator changed slightly compared to @jhusain's original to match rxjs 5.

Managed to flow type the pipe method using an intersection of function types rather than multiple `declare function` overloads which only works for functions.