### PR TITLE
feat: export pipeable operators directly from root module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ rxobs.subscribe({
 The `pipe` instance method can be used to apply operators to an Observable.
 
 ```js
-const { Observable, operators: { map } } = require("falcor-observable");
+const { Observable,  map } = require("falcor-observable");
 
 Observable.of(1,2,3)
   .pipe(

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,5 @@ export type {
   IClassicSubscriptionObserver as IObserver
 } from "./classic-observer";
 
-const { Observable } = require("./classic-observable");
-const operators = require("./operators");
-
-module.exports = { Observable, operators };
+module.exports.Operators = require("./classic-observable").Observable;
+module.exports.map = require("./operators/map").map;

--- a/src/operators/index.js
+++ b/src/operators/index.js
@@ -1,3 +1,0 @@
-// @flow
-"use strict";
-module.exports.map = require("./map").map;


### PR DESCRIPTION
BREAKING CHANGE: pipeable operators are no longer nested under 'operators'.