### PR TITLE
feat: Observable.defer

### DIFF
--- a/src/es-observable.js
+++ b/src/es-observable.js
@@ -283,6 +283,14 @@ class BaseObservable<T, E = Error> {
       observer.error(errorValue);
     });
   }
+
+  static defer(factory: () => ObservableInput<T, E>): this {
+    return new this(observer => {
+      const result = factory();
+      const obs = this.from(result);
+      return new Subscription(obs._subscriber, observer);
+    });
+  }
 }
 
 class EsObservable<T, E = Error> extends BaseObservable<T, E>
@@ -316,6 +324,11 @@ class EsObservable<T, E = Error> extends BaseObservable<T, E>
   static from(obsOrIter: ObservableInput<T, E>): this {
     const C = typeof this === "function" ? this : (EsObservable: any);
     return super.from.call(C, obsOrIter);
+  }
+
+  static defer(factory: () => ObservableInput<T, E>): this {
+    const C = typeof this === "function" ? this : (EsObservable: any);
+    return super.defer.call(C, factory);
   }
 
   pipe: (() => EsObservable<T, E>) &

--- a/test/classic-observable-test.js
+++ b/test/classic-observable-test.js
@@ -99,4 +99,22 @@ describe("Classic Observable", function() {
       expect(onCompleted.calledOnce).equal(true);
     });
   });
+
+  describe("defer", function() {
+    it("defers", function() {
+      const onNext = stub();
+      const onError = stub();
+      const onCompleted = stub();
+
+      Observable.defer(() => Observable.of(0, 1, 2)).subscribe({
+        onNext,
+        onError,
+        onCompleted
+      });
+
+      expect(onNext.args).to.deep.equal([[0], [1], [2]]);
+      expect(onError.called).equal(false);
+      expect(onCompleted.calledOnce).equal(true);
+    });
+  });
 });

--- a/test/es-observable-test.js
+++ b/test/es-observable-test.js
@@ -100,4 +100,22 @@ describe("ES Observable", function() {
       expect(complete.calledOnce).equal(true);
     });
   });
+
+  describe("defer", function() {
+    it("defers", function() {
+      const next = stub();
+      const error = stub();
+      const complete = stub();
+
+      Observable.defer(() => Observable.of(0, 1, 2)).subscribe({
+        next,
+        error,
+        complete
+      });
+
+      expect(next.args).to.deep.equal([[0], [1], [2]]);
+      expect(error.called).equal(false);
+      expect(complete.calledOnce).equal(true);
+    });
+  });
 });


### PR DESCRIPTION
This moves the implementation to BaseObservable. We don't need extra error checking here since we already handle errors in the subscriber function.

Note as of now we cannot defer a function returning IClassicObservable. While it feels a little icky it may make sense in this library for Observable.from to assume a non-symbolObservable, non-iterable argument with a subscribe method to be an IClassicObservable.