### PR TITLE
feat: adapt from Promise and classic observables in from

### DIFF
--- a/test/classic-observable-test.js
+++ b/test/classic-observable-test.js
@@ -57,7 +57,7 @@ describe("Classic Observable", function() {
     });
   });
 
-  describe("fromClassicObservable", function() {
+  describe("from", function() {
     it("adapts from classic observable", function() {
       const disposable = {
         isDisposed: false,
@@ -72,7 +72,7 @@ describe("Classic Observable", function() {
           return disposable;
         }
       };
-      const obs = Observable.fromClassicObservable(classic);
+      const obs = Observable.from(classic);
       const onNext = stub();
       const onError = stub();
       const onCompleted = stub();

--- a/test/es-observable-test.js
+++ b/test/es-observable-test.js
@@ -58,7 +58,7 @@ describe("ES Observable", function() {
     });
   });
 
-  describe("fromClassicObservable", function() {
+  describe("from", function() {
     it("adapts from classic observable", function() {
       const disposable = {
         isDisposed: false,
@@ -73,7 +73,7 @@ describe("ES Observable", function() {
           return disposable;
         }
       };
-      const obs = Observable.fromClassicObservable(classic);
+      const obs = Observable.from(classic);
       const next = stub();
       const error = stub();
       const complete = stub();
@@ -82,6 +82,40 @@ describe("ES Observable", function() {
       expect(next.args).to.deep.equal([[1]]);
       subscription.unsubscribe();
       expect(disposable.isDisposed).to.equal(true);
+    });
+
+    it("adapts from Promise (resolve)", function(done) {
+      const obs = Observable.from(new Promise((resolve, reject) => resolve(1)));
+      const next = stub();
+      obs.subscribe({
+        next,
+        error(e) {
+          done(e);
+        },
+        complete() {
+          expect(next.args).to.deep.equal([[1]]);
+          done();
+        }
+      });
+    });
+
+    it("adapts from Promise (reject)", function(done) {
+      const err = new Error("my error");
+      const obs = Observable.from(
+        new Promise((resolve, reject) => reject(err))
+      );
+      const next = stub();
+      obs.subscribe({
+        next,
+        error(e) {
+          expect(e).to.equal(err);
+          expect(next.called).to.equal(false);
+          done();
+        },
+        complete() {
+          throw new Error("should not reach here");
+        }
+      });
     });
   });
 


### PR DESCRIPTION
This allows classic observables (and promises) to be returned when using operators like mergeMap.